### PR TITLE
Ci sniff adjustments

### DIFF
--- a/CodeIgniter/Sniffs/NamingConventions/ValidFileNameSniff.php
+++ b/CodeIgniter/Sniffs/NamingConventions/ValidFileNameSniff.php
@@ -55,18 +55,18 @@ class CodeIgniter_Sniffs_NamingConventions_ValidFileNameSniff implements PHP_Cod
         // computes the expected filename based on the name of the class or interface that it contains.
         $decNamePtr = $phpcsFile->findNext(T_STRING, $stackPtr);
         $decName = $tokens[$decNamePtr]['content'];
-        $expectedFileName = strtolower($decName);
+        $expectedFileName = ucfirst(strtolower($decName));
         // extracts filename without extension from its path.
         $fullPath = $phpcsFile->getFilename();
         $fileNameAndExt = basename($fullPath);
         $fileName = substr($fileNameAndExt, 0, strrpos($fileNameAndExt, '.'));
 
         if ($expectedFileName !== $fileName) {
-            $errorTemplate = 'Filename "%s" doesn\'t match the name of the %s that it contains "%s" in lower case. "%s" was expected.';
+            $errorTemplate = 'Filename "%s" doesn\'t match the name of the %s that it contains "%s" in Ucfirst-like manner. "%s" was expected.';
             $errorMessage = sprintf(
                 $errorTemplate,
                 $fileName,
-                strtolower($tokens[$stackPtr]['content']), // class or interface
+                ucfirst(strtolower($tokens[$stackPtr]['content'])), // class or interface
                 $decName,
                 $expectedFileName
             );

--- a/CodeIgniter/ruleset.xml
+++ b/CodeIgniter/ruleset.xml
@@ -21,11 +21,19 @@
   <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
 
   <!-- Classes and functions should be commented -->
-  <rule ref="PEAR.Commenting.ClassComment"/>
+  <rule ref="PEAR.Commenting.ClassComment">
+      <exclude name="PEAR.Commenting.ClassComment.MissingAuthorTag"/>
+      <exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag"/>
+      <exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag"/>
+      <exclude name="PEAR.Commenting.ClassComment.MissingLinkTag"/>
+      <exclude name="PEAR.Commenting.ClassComment.MissingPackageTag"/>
+  </rule>
+
   <rule ref="PEAR.Commenting.FunctionComment"/>
   <rule ref="Squiz.Commenting.FunctionCommentThrowTag"/>
   <!-- Use warnings for docblock comments for files and variables, since nothing is cleary explained -->
   <rule ref="PEAR.Commenting.FileComment">
+      <exclude name="PEAR.Commenting.FileComment.Missing"/>
     <properties>
       <property name="error" value="false"/>
     </properties>


### PR DESCRIPTION
Fixes file naming sniff to match CI coding standard
Removes optional file/class comment rules